### PR TITLE
find all new chain starts by inspecting atom_array.hetero[c_start:c_stop]

### DIFF
--- a/protenix/data/utils.py
+++ b/protenix/data/utils.py
@@ -720,15 +720,17 @@ def pdb_to_cif(input_fname: str, output_fname: str, entry_id: str = None):
     new_chain_starts = []
     for c_start, c_stop in zip(chain_starts[:-1], chain_starts[1:]):
         new_chain_starts.append(c_start)
-        chain_start_hetero = atom_array.hetero[c_start]
-        hetero_diff = np.where(atom_array.hetero[c_start:c_stop] != chain_start_hetero)
+        if c_stop - c_start <= 1:
+            continue
+        hetero_diff = np.where(atom_array.hetero[c_start:(c_stop-1)] != atom_array.hetero[(c_start+1):c_stop])
         if hetero_diff[0].shape[0] > 0:
-            new_chain_start = c_start + hetero_diff[0][0]
-            new_chain_starts.append(new_chain_start)
+            for i in range(hetero_diff[0].shape[0]):
+                new_chain_start = c_start + hetero_diff[0][i] + 1
+                new_chain_starts.append(new_chain_start)
 
-    new_chain_starts += [chain_starts[-1]]
+    new_chain_starts.append(chain_starts[-1])
 
-    # # split HETATM chains by res id
+    # split HETATM chains by res id
     new_chain_starts2 = []
     for c_start, c_stop in zip(new_chain_starts[:-1], new_chain_starts[1:]):
         new_chain_starts2.append(c_start)


### PR DESCRIPTION
In atom_array.hetero[c_start:c_stop],  if atom_array.hetero[i+1] is diffenrent from atom_array.hetero[i], then treat the index i+1 as a new chain start. Find all such i+1.

Checks for changes between ATOM and HETATM records. If found, adds new chain start at the transition point.